### PR TITLE
Introduce the Update URI to the plugin header

### DIFF
--- a/options-importer.php
+++ b/options-importer.php
@@ -6,6 +6,7 @@
  * Version: 7
  * Author: Matthew Boynes
  * Author URI: https://alley.co/
+ * Update URI: https://github.com/alleyinteractive/options-importer
  *
  * @package Options_Importer
  */


### PR DESCRIPTION
As the [WordPress.org plugin](https://wordpress.org/plugins/options-importer/) isn't up-to-date with this Github repo, WordPress reports that the installed version is higher than expected when installing from Github.

This change leverages the [new Update URI plugin header](https://make.wordpress.org/core/2021/06/29/introducing-update-uri-plugin-header-in-wordpress-5-8/) to prevent this happening, by specifying that this Github repo is the right place for updates, not WP.org.